### PR TITLE
Changed check for maybe unknown optional ores

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -26,7 +26,7 @@
 	2017-06-20  v0.05  * Hammer sound bugfix
 	2017-06-24 	v1.00  * Released version w/o any changes
 	2017-07-08  V1.01  * extended for moreores
-	
+
 ]]--
 
 gravelsieve = {
@@ -38,23 +38,22 @@ gravelsieve.ore_rarity = tonumber(minetest.setting_get("gravelsieve_ore_rarity")
 
 
 -- Ore probability table  (1/n)
-local ore_probability = {
+gravelsieve.ore_probability = {
 	["default:iron_lump"] = 35,
 	["default:copper_lump"] = 60,
 	["default:tin_lump"] = 80,
 	["default:gold_lump"] = 175,
 	["default:mese_crystal"] = 275,
 	["default:diamond"] = 340,
+	["moreores:silver_lump"] = 100,
+	["moreores:mithril_lump"] = 250,
 }
 
-if minetest.get_modpath("moreores") then
-	ore_probability["moreores:silver_lump"] = 100
-	ore_probability["moreores:mithril_lump"] = 250
-end
-
--- check if tin is available
-if ItemStack("default:tin_lump") == nil then
-	ore_probability["tin_lump"] = nil     -- not available
+-- remove not registered ores from list
+for ore, probability in pairs(gravelsieve.ore_probability) do
+	if not minetest.registered_items[ore] then
+		gravelsieve.ore_probability[ore] = nil
+	end
 end
 
 local sieve_formspec =
@@ -112,16 +111,14 @@ end
 -- place ores to dst according to the calculated probability
 local function random_ore(inv, src)
 	local num
-	for ore, probability in pairs(ore_probability) do
+	for ore, probability in pairs(gravelsieve.ore_probability) do
 		-- calculate the probability based on user configuration
 		probability = probability * gravelsieve.ore_rarity
-		if probability ~= nil then
-			if math.random(probability) == 1 then
-				local item = ItemStack(ore)
-				if inv:room_for_item("dst", item) then
-					inv:add_item("dst", item)
-					return true     -- ore placed
-				end
+		if math.random(probability) == 1 then
+			local item = ItemStack(ore)
+			if inv:room_for_item("dst", item) then
+				inv:add_item("dst", item)
+				return true     -- ore placed
 			end
 		end
 	end


### PR DESCRIPTION
EDITED (and patch replaced, the first attempt was not good)

3x changes from my site
1. check against minetest.registered_items[ore] and remove it from table if unknown.
2. The ore_probability is now global accessable gravelsieve attribute so other mods could directly append additional ores to the table. 
3. removed not needed check against probability ~= nil
